### PR TITLE
Set provider for analytitcs

### DIFF
--- a/scripts/cloud-config.yaml
+++ b/scripts/cloud-config.yaml
@@ -36,7 +36,7 @@ write_files:
       [Service]
       Type=simple
       ExecStart=/usr/bin/meilisearch --db-path /var/lib/meilisearch/data.ms --env development
-      Environment="MEILI_SERVER_PROVIDER=digital_ocean"
+      Environment="MEILI_SERVER_PROVIDER=unknown_provider"
 
       [Install]
       WantedBy=default.target


### PR DESCRIPTION
Closes #31 

This follows our discussion @eskombro about how we should set the provider at build time for each provider/specific script.

This pr set the `MEILI_SERVER_PROVIDER` to `unknown_provider` in `cloud-config.yaml`.
It will then be changed by each provider build by rewriting the `cloud-config.yaml` that is downloaded.

Open to suggestions 😁
