### PR TITLE
Default user for each provider

### DIFF
--- a/scripts/cloud-config.yaml
+++ b/scripts/cloud-config.yaml
@@ -7,12 +7,6 @@ package_upgrade: true
 
 users:
   - default
-  - name: meilisearch
-    sudo: ['ALL=(ALL) NOPASSWD:ALL']
-    ssh_import_id: root
-    lock_passwd: True
-    shell: /bin/bash
-    groups: [sudo]
   - name: root
     shell: /bin/bash
 

--- a/scripts/deploy-meilisearch.sh
+++ b/scripts/deploy-meilisearch.sh
@@ -15,12 +15,3 @@ touch /var/opt/meilisearch/env
 echo "source /var/opt/meilisearch/env" >> /root/.bashrc
 echo "source /var/opt/meilisearch/env" >> /home/meilisearch/.bashrc
 echo "source /var/opt/meilisearch/env" >> /etc/skel/.bashrc
-
-# Config meilisearch ssh
-if [ "$2" = "AWS" ]; then
-    cp -r /home/admin/.ssh /home/meilisearch/.
-else
-    cp -r /root/.ssh /home/meilisearch/.
-fi
-chown -R meilisearch /home/meilisearch/.ssh
-chown -R meilisearch /var/opt/meilisearch


### PR DESCRIPTION
closes #38 

This is meant to simplify the removal of the ssh commands (#37 ), the cleaning ot the meilisearch-cloud repositories and prepare a potential fix where the ssh keys for the user meilisearch are not copied when a user creates a meilisearch machine through a provider.