### PR TITLE
Revert user meilisearch creation in cloud-config

### DIFF
--- a/scripts/providers/aws/cloud-config.yaml
+++ b/scripts/providers/aws/cloud-config.yaml
@@ -6,12 +6,6 @@ package_upgrade: true
 
 users:
   - default
-  - name: meilisearch
-    sudo: ['ALL=(ALL) NOPASSWD:ALL']
-    ssh_import_id: root
-    lock_passwd: True
-    shell: /bin/bash
-    groups: [sudo]
   - name: root
     shell: /bin/bash
 

--- a/scripts/providers/digitalocean/cloud-config.yaml
+++ b/scripts/providers/digitalocean/cloud-config.yaml
@@ -6,12 +6,6 @@ package_upgrade: true
 
 users:
   - default
-  - name: meilisearch
-    sudo: ['ALL=(ALL) NOPASSWD:ALL']
-    ssh_import_id: root
-    lock_passwd: True
-    shell: /bin/bash
-    groups: [sudo]
   - name: root
     shell: /bin/bash
 

--- a/scripts/providers/gcp/cloud-config.yaml
+++ b/scripts/providers/gcp/cloud-config.yaml
@@ -6,12 +6,6 @@ package_upgrade: true
 
 users:
   - default
-  - name: meilisearch
-    sudo: ['ALL=(ALL) NOPASSWD:ALL']
-    ssh_import_id: root
-    lock_passwd: True
-    shell: /bin/bash
-    groups: [sudo]
   - name: root
     shell: /bin/bash
 


### PR DESCRIPTION
User meilisearch should not be created for any provider in this version. See #39 