### PR TITLE
Patch - Bump meilisearch v0.29.0

### DIFF
--- a/scripts/deploy-meilisearch.sh
+++ b/scripts/deploy-meilisearch.sh
@@ -15,5 +15,4 @@ rm -rf /tmp/meili-tmp
 # Set launch Meilisearch first login script
 touch /var/opt/meilisearch/env
 echo 'source /var/opt/meilisearch/env' >> /root/.bashrc
-echo 'source /var/opt/meilisearch/env' >> /home/meilisearch/.bashrc
 echo 'source /var/opt/meilisearch/env' >> /etc/skel/.bashrc

--- a/scripts/providers/aws/cloud-config.yaml
+++ b/scripts/providers/aws/cloud-config.yaml
@@ -62,13 +62,13 @@ write_files:
       meilisearch-setup
 
 runcmd:
-  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.28.1/meilisearch-linux-amd64
+  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0rc0/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service
   - ufw --force enable
   - ufw allow 'Nginx Full'
   - ufw allow 'OpenSSH'
-  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.28.1/scripts/deploy-meilisearch.sh | bash -s v0.28.1 aws
+  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.28.1 aws
 
 power_state:
   mode: reboot

--- a/scripts/providers/aws/cloud-config.yaml
+++ b/scripts/providers/aws/cloud-config.yaml
@@ -15,7 +15,7 @@ packages:
   - ufw
   - gcc
   - make
-  - nginx-light
+  - nginx-core
   - certbot
   - python-certbot-nginx
 

--- a/scripts/providers/aws/cloud-config.yaml
+++ b/scripts/providers/aws/cloud-config.yaml
@@ -62,6 +62,7 @@ write_files:
       meilisearch-setup
 
 runcmd:
+  - apt install nginx -y
   - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service

--- a/scripts/providers/aws/cloud-config.yaml
+++ b/scripts/providers/aws/cloud-config.yaml
@@ -62,7 +62,7 @@ write_files:
       meilisearch-setup
 
 runcmd:
-  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0rc0/meilisearch-linux-amd64
+  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0rc4/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service
   - ufw --force enable

--- a/scripts/providers/aws/cloud-config.yaml
+++ b/scripts/providers/aws/cloud-config.yaml
@@ -69,7 +69,7 @@ runcmd:
   - ufw --force enable
   - ufw allow 'Nginx Full'
   - ufw allow 'OpenSSH'
-  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.29.0 aws
+  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0/scripts/deploy-meilisearch.sh | bash -s v0.29.0 aws
 
 power_state:
   mode: reboot

--- a/scripts/providers/aws/cloud-config.yaml
+++ b/scripts/providers/aws/cloud-config.yaml
@@ -15,7 +15,7 @@ packages:
   - ufw
   - gcc
   - make
-  - nginx
+  - nginx-light
   - certbot
   - python-certbot-nginx
 
@@ -62,7 +62,7 @@ write_files:
       meilisearch-setup
 
 runcmd:
-  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0rc4/meilisearch-linux-amd64
+  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service
   - ufw --force enable

--- a/scripts/providers/aws/cloud-config.yaml
+++ b/scripts/providers/aws/cloud-config.yaml
@@ -15,7 +15,7 @@ packages:
   - ufw
   - gcc
   - make
-  - nginx-core
+  - nginx
   - certbot
   - python-certbot-nginx
 

--- a/scripts/providers/aws/cloud-config.yaml
+++ b/scripts/providers/aws/cloud-config.yaml
@@ -68,7 +68,7 @@ runcmd:
   - ufw --force enable
   - ufw allow 'Nginx Full'
   - ufw allow 'OpenSSH'
-  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.28.1 aws
+  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.29.0 aws
 
 power_state:
   mode: reboot

--- a/scripts/providers/digitalocean/cloud-config.yaml
+++ b/scripts/providers/digitalocean/cloud-config.yaml
@@ -10,12 +10,12 @@ users:
     shell: /bin/bash
 
 packages:  
-  - nginx
   - git
   - curl
   - ufw
   - gcc
   - make
+  - nginx
   - certbot
   - python-certbot-nginx
 
@@ -69,9 +69,9 @@ runcmd:
   - ufw --force enable
   - ufw allow 'Nginx Full'
   - ufw allow 'OpenSSH'
-  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.29.0 digitalocean
-  # - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/90-cleanup.sh | bash
-  # - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh | bash
+  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0/scripts/deploy-meilisearch.sh | bash -s v0.29.0 digitalocean
+  - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/90-cleanup.sh | bash
+  - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh | bash
 
 power_state:
   mode: reboot

--- a/scripts/providers/digitalocean/cloud-config.yaml
+++ b/scripts/providers/digitalocean/cloud-config.yaml
@@ -15,7 +15,7 @@ packages:
   - ufw
   - gcc
   - make
-  - nginx-light
+  - nginx-core
   - certbot
   - python-certbot-nginx
 

--- a/scripts/providers/digitalocean/cloud-config.yaml
+++ b/scripts/providers/digitalocean/cloud-config.yaml
@@ -62,7 +62,8 @@ write_files:
       meilisearch-setup
 
 runcmd:
-  - apt install nginx
+  - apt install nginx -y
+  - apt install python-certbot-nginx -y
   - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service

--- a/scripts/providers/digitalocean/cloud-config.yaml
+++ b/scripts/providers/digitalocean/cloud-config.yaml
@@ -62,13 +62,13 @@ write_files:
       meilisearch-setup
 
 runcmd:
-  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.28.1/meilisearch-linux-amd64
+  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0rc0/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service
   - ufw --force enable
   - ufw allow 'Nginx Full'
   - ufw allow 'OpenSSH'
-  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.28.1/scripts/deploy-meilisearch.sh | bash -s v0.28.1 digitalocean
+  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.28.1 digitalocean
   - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/90-cleanup.sh | bash
   - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh | bash
 

--- a/scripts/providers/digitalocean/cloud-config.yaml
+++ b/scripts/providers/digitalocean/cloud-config.yaml
@@ -62,7 +62,7 @@ write_files:
       meilisearch-setup
 
 runcmd:
-  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0rc0/meilisearch-linux-amd64
+  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0rc4/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service
   - ufw --force enable

--- a/scripts/providers/digitalocean/cloud-config.yaml
+++ b/scripts/providers/digitalocean/cloud-config.yaml
@@ -15,7 +15,7 @@ packages:
   - ufw
   - gcc
   - make
-  - nginx
+  - nginx-light
   - certbot
   - python-certbot-nginx
 
@@ -62,7 +62,7 @@ write_files:
       meilisearch-setup
 
 runcmd:
-  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0rc4/meilisearch-linux-amd64
+  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service
   - ufw --force enable

--- a/scripts/providers/digitalocean/cloud-config.yaml
+++ b/scripts/providers/digitalocean/cloud-config.yaml
@@ -10,12 +10,12 @@ users:
     shell: /bin/bash
 
 packages:  
+  - nginx
   - git
   - curl
   - ufw
   - gcc
   - make
-  - nginx
   - certbot
   - python-certbot-nginx
 
@@ -70,8 +70,8 @@ runcmd:
   - ufw allow 'Nginx Full'
   - ufw allow 'OpenSSH'
   - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.29.0 digitalocean
-  - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/90-cleanup.sh | bash
-  - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh | bash
+  # - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/90-cleanup.sh | bash
+  # - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh | bash
 
 power_state:
   mode: reboot

--- a/scripts/providers/digitalocean/cloud-config.yaml
+++ b/scripts/providers/digitalocean/cloud-config.yaml
@@ -15,7 +15,7 @@ packages:
   - ufw
   - gcc
   - make
-  - nginx-core
+  - nginx
   - certbot
   - python-certbot-nginx
 
@@ -62,6 +62,7 @@ write_files:
       meilisearch-setup
 
 runcmd:
+  - apt install nginx
   - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service

--- a/scripts/providers/digitalocean/cloud-config.yaml
+++ b/scripts/providers/digitalocean/cloud-config.yaml
@@ -63,7 +63,6 @@ write_files:
 
 runcmd:
   - apt install nginx -y
-  - apt install python-certbot-nginx -y
   - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service

--- a/scripts/providers/digitalocean/cloud-config.yaml
+++ b/scripts/providers/digitalocean/cloud-config.yaml
@@ -68,7 +68,7 @@ runcmd:
   - ufw --force enable
   - ufw allow 'Nginx Full'
   - ufw allow 'OpenSSH'
-  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.28.1 digitalocean
+  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.29.0 digitalocean
   - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/90-cleanup.sh | bash
   - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh | bash
 

--- a/scripts/providers/gcp/cloud-config.yaml
+++ b/scripts/providers/gcp/cloud-config.yaml
@@ -16,7 +16,7 @@ packages:
   - ufw
   - gcc
   - make
-  - nginx
+  - nginx-light
   - certbot
   - python-certbot-nginx
 
@@ -63,7 +63,7 @@ write_files:
       meilisearch-setup
 
 runcmd:
-  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0rc4/meilisearch-linux-amd64
+  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service
   - ufw --force enable

--- a/scripts/providers/gcp/cloud-config.yaml
+++ b/scripts/providers/gcp/cloud-config.yaml
@@ -16,7 +16,7 @@ packages:
   - ufw
   - gcc
   - make
-  - nginx-core
+  - nginx
   - certbot
   - python-certbot-nginx
 
@@ -70,7 +70,7 @@ runcmd:
   - ufw --force enable
   - ufw allow 'Nginx Full'
   - ufw allow 'OpenSSH'
-  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.29.0 gcp
+  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0/scripts/deploy-meilisearch.sh | bash -s v0.29.0 gcp
 
 power_state:
   mode: reboot

--- a/scripts/providers/gcp/cloud-config.yaml
+++ b/scripts/providers/gcp/cloud-config.yaml
@@ -69,7 +69,7 @@ runcmd:
   - ufw --force enable
   - ufw allow 'Nginx Full'
   - ufw allow 'OpenSSH'
-  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.28.1 gcp
+  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.29.0 gcp
 
 power_state:
   mode: reboot

--- a/scripts/providers/gcp/cloud-config.yaml
+++ b/scripts/providers/gcp/cloud-config.yaml
@@ -16,7 +16,7 @@ packages:
   - ufw
   - gcc
   - make
-  - nginx-light
+  - nginx-core
   - certbot
   - python-certbot-nginx
 

--- a/scripts/providers/gcp/cloud-config.yaml
+++ b/scripts/providers/gcp/cloud-config.yaml
@@ -63,7 +63,7 @@ write_files:
       meilisearch-setup
 
 runcmd:
-  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0rc0/meilisearch-linux-amd64
+  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0rc4/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service
   - ufw --force enable

--- a/scripts/providers/gcp/cloud-config.yaml
+++ b/scripts/providers/gcp/cloud-config.yaml
@@ -63,13 +63,13 @@ write_files:
       meilisearch-setup
 
 runcmd:
-  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.28.1/meilisearch-linux-amd64
+  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0rc0/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service
   - ufw --force enable
   - ufw allow 'Nginx Full'
   - ufw allow 'OpenSSH'
-  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.28.1/scripts/deploy-meilisearch.sh | bash -s v0.28.1 gcp
+  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/v0.29.0-rc/scripts/deploy-meilisearch.sh | bash -s v0.28.1 gcp
 
 power_state:
   mode: reboot

--- a/scripts/providers/gcp/cloud-config.yaml
+++ b/scripts/providers/gcp/cloud-config.yaml
@@ -63,6 +63,7 @@ write_files:
       meilisearch-setup
 
 runcmd:
+  - apt install nginx -y
   - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service


### PR DESCRIPTION
The purpose of this PR is to fix the fact that Nginx is not installed via `cloud-init` `packages` for an unknown reason.
A `runcmd` to install it has been added