### PR TITLE
Purge droplet agent for img_check script

### DIFF
--- a/scripts/providers/digitalocean/cloud-config.yaml
+++ b/scripts/providers/digitalocean/cloud-config.yaml
@@ -63,6 +63,7 @@ write_files:
 
 runcmd:
   - apt install nginx -y
+  - apt-get purge droplet-agent* -y
   - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/meilisearch/releases/download/v0.29.0/meilisearch-linux-amd64
   - chmod 755 /usr/bin/meilisearch
   - systemctl enable meilisearch.service


### PR DESCRIPTION
The submission of the new image in DigitalOcean platform didn't work following after running the script `img_check.sh` they provided due to this error:
```bash
[41m[FAIL][0m DigitalOcean directory detected.
To uninstall the agent and remove the DO directory: 'sudo apt-get purge droplet-agent'
```